### PR TITLE
Remove contenteditable attribute

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -510,13 +510,11 @@ function insertText(textarea, _ref) {
   var after = textarea.value.slice(textarea.selectionEnd);
 
   if (canInsertText === null || canInsertText === true) {
-    textarea.contentEditable = 'true';
     try {
       canInsertText = document.execCommand('insertText', false, text);
     } catch (error) {
       canInsertText = false;
     }
-    textarea.contentEditable = 'false';
   }
 
   if (canInsertText && !textarea.value.slice(0, textarea.selectionStart).endsWith(text)) {

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -581,13 +581,11 @@
     var after = textarea.value.slice(textarea.selectionEnd);
 
     if (canInsertText === null || canInsertText === true) {
-      textarea.contentEditable = 'true';
       try {
         canInsertText = document.execCommand('insertText', false, text);
       } catch (error) {
         canInsertText = false;
       }
-      textarea.contentEditable = 'false';
     }
 
     if (canInsertText && !textarea.value.slice(0, textarea.selectionStart).endsWith(text)) {

--- a/index.js
+++ b/index.js
@@ -332,13 +332,11 @@ function insertText(textarea: HTMLTextAreaElement, {text, selectionStart, select
   const after = textarea.value.slice(textarea.selectionEnd)
 
   if (canInsertText === null || canInsertText === true) {
-    textarea.contentEditable = 'true'
     try {
       canInsertText = document.execCommand('insertText', false, text)
     } catch (error) {
       canInsertText = false
     }
-    textarea.contentEditable = 'false'
   }
 
   if (canInsertText && !textarea.value.slice(0, textarea.selectionStart).endsWith(text)) {


### PR DESCRIPTION
Remove `contenteditable` attribute as it currently blocks users from editing the textarea after injecting markdown on IE11.

https://trello.com/c/fLfbI7Vi