### PR TITLE
Fix ordered list

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -324,7 +324,7 @@ var MarkdownOrderedListButtonElement = function (_MarkdownButtonElemen13) {
 
     var _this14 = _possibleConstructorReturn(this, (MarkdownOrderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownOrderedListButtonElement)).call(this));
 
-    styles.set(_this14, { prefix: '1. ', multiline: true, orderedList: true });
+    styles.set(_this14, { prefix: '1. ', multiline: true, surroundWithNewlines: true, orderedList: true });
     return _this14;
   }
 
@@ -547,7 +547,7 @@ function styleSelectedText(textarea, styleArgs) {
   var text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd);
 
   var result = void 0;
-  if (styleArgs.orderedList) {
+  if (styleArgs.orderedList && text) {
     result = orderedList(textarea);
   } else if (styleArgs.multiline && isMultipleLines(text)) {
     result = multilineStyle(textarea, styleArgs);

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -395,7 +395,7 @@
 
       var _this14 = _possibleConstructorReturn(this, (MarkdownOrderedListButtonElement.__proto__ || Object.getPrototypeOf(MarkdownOrderedListButtonElement)).call(this));
 
-      styles.set(_this14, { prefix: '1. ', multiline: true, orderedList: true });
+      styles.set(_this14, { prefix: '1. ', multiline: true, surroundWithNewlines: true, orderedList: true });
       return _this14;
     }
 
@@ -618,7 +618,7 @@
     var text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd);
 
     var result = void 0;
-    if (styleArgs.orderedList) {
+    if (styleArgs.orderedList && text) {
       result = orderedList(textarea);
     } else if (styleArgs.multiline && isMultipleLines(text)) {
       result = multilineStyle(textarea, styleArgs);

--- a/index.js
+++ b/index.js
@@ -196,7 +196,7 @@ if (!window.customElements.get('md-unordered-list')) {
 class MarkdownOrderedListButtonElement extends MarkdownButtonElement {
   constructor() {
     super()
-    styles.set(this, {prefix: '1. ', multiline: true, orderedList: true})
+    styles.set(this, {prefix: '1. ', multiline: true, surroundWithNewlines: true, orderedList: true})
   }
 }
 
@@ -369,7 +369,7 @@ function styleSelectedText(textarea: HTMLTextAreaElement, styleArgs: StyleArgs) 
   const text = textarea.value.slice(textarea.selectionStart, textarea.selectionEnd)
 
   let result
-  if (styleArgs.orderedList) {
+  if (styleArgs.orderedList && text) {
     result = orderedList(textarea)
   } else if (styleArgs.multiline && isMultipleLines(text)) {
     result = multilineStyle(textarea, styleArgs)


### PR DESCRIPTION
Run the orderedList style args only when we have a selection, otherwise we default on a simple prefixing.