### PR TITLE
Expose two private methods as public

### DIFF
--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -786,4 +786,7 @@ function applyStyle(button, styles) {
   }
 }
 
+MarkdownToolbarElement.insertText = insertText;
+MarkdownToolbarElement.newlinesToSurroundSelectedText = newlinesToSurroundSelectedText;
+
 export default MarkdownToolbarElement;

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -857,5 +857,8 @@
     }
   }
 
+  MarkdownToolbarElement.insertText = insertText;
+  MarkdownToolbarElement.newlinesToSurroundSelectedText = newlinesToSurroundSelectedText;
+
   exports.default = MarkdownToolbarElement;
 });

--- a/index.js
+++ b/index.js
@@ -605,4 +605,7 @@ function applyStyle(button: Element, styles: {}) {
   }
 }
 
+MarkdownToolbarElement.insertText = insertText
+MarkdownToolbarElement.newlinesToSurroundSelectedText = newlinesToSurroundSelectedText
+
 export default MarkdownToolbarElement


### PR DESCRIPTION
This is to fix that the vendored copy of Content Publisher is exposing
a private method (insertText) and had deviated from the version supplied
in this repo.

This adds this method exposure into the source code and adds another
one: newlinesToSurroundSelectedText, which can be used to determine the
spacing around a block element.

It isn't ideal to be doing this as this only deviates this fork from
upstream. Hopefully in the future Content Publisher has different means
to insert text that don't involve using this private API.