### PR TITLE
Remove md-link-email and reorder

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -13,22 +13,21 @@
             <h1 class="govuk-heading-xl">markdown-toolbar element</h1>
             <p class="govuk-body">Markdown formatting buttons for text inputs</p>
             <markdown-toolbar for="textarea">
-              <md-header class="govuk-button">header</md-header>
+              <md-header class="govuk-button">heading 1</md-header>
+              <md-header-2 class="govuk-button">heading 2</md-header-2>
+              <md-header-3 class="govuk-button">heading 3</md-header-3>
+              <md-header-4 class="govuk-button">heading 4</md-header-4>
               <md-bold class="govuk-button">bold</md-bold>
               <md-italic class="govuk-button">italic</md-italic>
               <md-quote class="govuk-button">quote</md-quote>
               <md-code class="govuk-button">code</md-code>
               <md-link class="govuk-button">link</md-link>
-              <md-unordered-list class="govuk-button">unordered-list</md-unordered-list>
-              <md-ordered-list class="govuk-button">ordered-list</md-ordered-list>
-              <md-task-list class="govuk-button">task-list</md-task-list>
+              <md-unordered-list class="govuk-button">unordered list</md-unordered-list>
+              <md-ordered-list class="govuk-button">ordered list</md-ordered-list>
+              <md-task-list class="govuk-button">task list</md-task-list>
               <md-mention class="govuk-button">mention</md-mention>
               <md-ref class="govuk-button">ref</md-ref>
-              <md-header-2 class="govuk-button">heading 2</md-header-2>
-              <md-header-3 class="govuk-button">heading 3</md-header-3>
-              <md-header-4 class="govuk-button">heading 4</md-header-4>
               <md-link-cta class="govuk-button">call to action link</md-link-cta>
-              <md-link-email class="govuk-button">email link</md-link-email>
               <md-address class="govuk-button">address</md-address>
             </markdown-toolbar>
             <textarea class="govuk-textarea" id="textarea" rows="10"></textarea>


### PR DESCRIPTION
Remove `md-link-email` from examples as this is covered by the `md-link` since 0.2.0