### PR TITLE
Deprecate markdown-toolbar-element

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: daily
     time: "03:00"
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 0
   ignore:
   - dependency-name: eslint
     versions:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# &lt;markdown-toolbar&gt; element
+# &lt;markdown-toolbar&gt; element (DEPRECATED)
+
+> **NOTE**: This project is deprecated and is [planned to be retired](https://trello.com/c/v6AT6hNR/88-remove-markdown-toolbar-element-from-content-publisher).
+
+---
 
 Markdown formatting buttons for text inputs.
 


### PR DESCRIPTION
As done in https://github.com/alphagov/content-publisher/pull/3287 and https://github.com/alphagov/maslow/pull/1293, we want to disable Dependabot PRs for this deprecated repo.